### PR TITLE
spn-9: Resize and center; responsive design

### DIFF
--- a/spinners/css/spinners.css
+++ b/spinners/css/spinners.css
@@ -691,7 +691,6 @@ body {
   width: 100%;
   height: 100%;
 }
-
 .spn-9:after {
   content: ' ';
   display: inline-block;
@@ -702,7 +701,6 @@ body {
   border-color: #fff transparent #fff transparent;
   animation: lds-dual-ring 1.2s linear infinite;
 }
-
 @keyframes lds-dual-ring {
   0% {
     transform: rotate(0deg);

--- a/spinners/css/spinners.css
+++ b/spinners/css/spinners.css
@@ -688,18 +688,15 @@ body {
 }
 
 .spn-9 {
-  margin: auto;
-  width: 10em;
-  height: 10em;
+  width: 100%;
+  height: 100%;
 }
 
 .spn-9:after {
   content: ' ';
   display: inline-block;
-  margin: 60px auto;
-  width: 10em;
-  height: 10em;
-  /* margin: 8px; */
+  width: calc(100% - 20px);
+  height: calc(100% - 20px);
   border-radius: 50%;
   border: 10px solid #fff;
   border-color: #fff transparent #fff transparent;


### PR DESCRIPTION
- Resize and center `spn-9` via percentages (7677547)
  - This results in a responsive design. The spinner will fill the entire space of the parent container, and margin/padding can be adjusted outside of the spinner for additional spacing. 

**Before**

https://user-images.githubusercontent.com/55961065/138606426-9530728b-ecb9-406d-9e21-b09d6932a018.mov


**After**

https://user-images.githubusercontent.com/55961065/138606427-a17b87b6-690c-4bb7-905a-907cc3f6e197.mov



