### PR TITLE
spn-10: Resize and center; responsive design

### DIFF
--- a/spinners/css/spinners.css
+++ b/spinners/css/spinners.css
@@ -717,9 +717,8 @@ body {
 
 .spn-10 {
   transform: translateZ(1px);
-  width: 10em;
-  height: 10em;
-  margin: 80px auto;
+  width: 100%;
+  height: 100%;
   border-radius: 50%;
   background: #fff;
   animation: lds-circle 2.4s cubic-bezier(0, 0.2, 0.8, 1) infinite;


### PR DESCRIPTION
- Resize and center `spn-10` via percentages (a18fc2c)
  - This results in a responsive design. The spinner will fill the entire space of the parent container, and margin/padding can be adjusted outside of the spinner for additional spacing. 

**Before**

https://user-images.githubusercontent.com/55961065/138606477-37269eca-11cf-46cf-a415-5f18ed9225d3.mov


**After**

https://user-images.githubusercontent.com/55961065/138606478-cd5c3e46-542f-4a7f-b84f-33bb59466599.mov



