### PR TITLE
spn-14: Resize and center; responsive design

### DIFF
--- a/spinners/css/spinners.css
+++ b/spinners/css/spinners.css
@@ -866,18 +866,17 @@ body {
 .spn-14 {
   display: inline-block;
   position: relative;
-  width: 80px;
-  height: 80px;
+  width: 100%;
+  height: 100%;
 }
 .spn-14 div {
   box-sizing: border-box;
   display: block;
   position: absolute;
-  top: 60px;
-  left: 60px;
-  width: 128px;
-  height: 128px;
-  margin: 16px;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
   border: 16px solid #fff;
   border-radius: 50%;
   animation: lds-ring 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;


### PR DESCRIPTION
- Resize and center `spn-14` via percentages (0a2feb3)
  - This results in a responsive design. The spinner will fill the entire space of the parent container, and margin/padding can be adjusted outside of the spinner for additional spacing. 

**Before**

https://user-images.githubusercontent.com/55961065/138606557-a596ac9e-171d-44c7-9e0c-a3f3cc2d13e4.mov


**After**

https://user-images.githubusercontent.com/55961065/138606560-6db3e027-d816-4217-9c0c-de5bc3be3d4f.mov
