### PR TITLE
spn-16: Resize and center; responsive design

### DIFF
--- a/spinners/css/spinners.css
+++ b/spinners/css/spinners.css
@@ -987,62 +987,46 @@ body {
 }
 
 .spn-16 {
-  display: inline-block;
+  display: grid;
+  grid-template: repeat(3, 1fr) / repeat(3, 1fr);
+  grid-gap: 11%;
   position: relative;
-  width: 80px;
-  height: 80px;
+  width: 100%;
+  height: 100%;
 }
 .spn-16 div {
-  position: absolute;
-  width: 32px;
-  height: 32px;
+  position: relative;
+  width: 100%;
+  height: 100%;
   border-radius: 50%;
   background: #fff;
   animation: lds-grid 1.2s linear infinite;
 }
 .spn-16 div:nth-child(1) {
-  top: 16px;
-  left: 16px;
   animation-delay: 0s;
 }
 .spn-16 div:nth-child(2) {
-  top: 16px;
-  left: 64px;
   animation-delay: -0.4s;
 }
 .spn-16 div:nth-child(3) {
-  top: 16px;
-  left: 112px;
   animation-delay: -0.8s;
 }
 .spn-16 div:nth-child(4) {
-  top: 64px;
-  left: 16px;
   animation-delay: -0.4s;
 }
 .spn-16 div:nth-child(5) {
-  top: 64px;
-  left: 64px;
   animation-delay: -0.8s;
 }
 .spn-16 div:nth-child(6) {
-  top: 64px;
-  left: 112px;
   animation-delay: -1.2s;
 }
 .spn-16 div:nth-child(7) {
-  top: 112px;
-  left: 16px;
   animation-delay: -0.8s;
 }
 .spn-16 div:nth-child(8) {
-  top: 112px;
-  left: 64px;
   animation-delay: -1.2s;
 }
 .spn-16 div:nth-child(9) {
-  top: 112px;
-  left: 112px;
   animation-delay: -1.6s;
 }
 @keyframes lds-grid {


### PR DESCRIPTION
- Resize and center `spn-16` via percentages and CSS Grid (8737004)
  - This results in a responsive design. The spinner will fill the entire space of the parent container, and margin/padding can be adjusted outside of the spinner for additional spacing. 

**Before**

https://user-images.githubusercontent.com/55961065/138606619-434742a0-3140-4276-93a9-6e96c8c45986.mov


**After**

https://user-images.githubusercontent.com/55961065/138606621-c07f764f-4f0e-4fa2-9c1c-7c2a273ba116.mov


